### PR TITLE
Use the user associated with the Jira client

### DIFF
--- a/cmd/monitor-jira-create-impact-statement-request/main.go
+++ b/cmd/monitor-jira-create-impact-statement-request/main.go
@@ -85,7 +85,6 @@ func main() {
 			Labels:      []string{updateblockers.LabelBlocker},
 			Description: fmt.Sprintf(descriptionTemplate, ocpbugsId, ocpbugsId),
 			Summary:     fmt.Sprintf("Impact statement request for %s %s", ocpbugsId, blockerCandidate.Fields.Summary),
-			Reporter:    &jira.User{Name: "afri@afri.cz"}, // TODO(muller): Use the user associated with the Jira client
 		},
 	}
 	if assignee != nil {


### PR DESCRIPTION
Tried with 

```bash
go run ./cmd/monitor-jira-create-impact-statement-request --bug 43587 --for AUTH --jira-bearer-token-file ~/.jira-token                                                                       
INFO[0000] Obtaining issue OCPBUGS-43587                
INFO[0000] Issue OCPBUGS-43587 is assigned to rh-ee-irinis 
INFO[0000] Creating impact statement request Spike card in AUTH project 
INFO[0001] Creating a 'AUTH-550 blocks OCPBUGS-43587' link between the cards 
INFO[0002] Adding an informative comment to OCPBUGS-43587 card 
INFO[0018] Adding the ImpactStatementRequested label to OCPBUGS-43587 card 
```

and it worked out.

<img width="184" alt="Screenshot 2024-10-30 at 10 02 31 AM" src="https://github.com/user-attachments/assets/1fbf4948-e1ba-49e6-b28a-52afa66e6bdd">
