### PR TITLE
Remove apiTokenFileRef in JiraOptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ go build ./cmd/monitor-jira-dashboard/   # Build the dashboard tool
 ### Running Tools
 ```bash
 # Interactive TUI for monitoring upgrade blockers
-./monitor -jira.bearer-token-file=~/.config/ota/jira-token
+./monitor --jira-username "kerberosid@redhat.com" --jira-password-file ~/.config/ota/.jira-api-token
 
 # Dashboard view of upgrade blocker status
-./monitor-jira-dashboard -jira.bearer-token-file=~/.config/ota/jira-token
+./monitor-jira-dashboard --jira-username "kerberosid@redhat.com" --jira-password-file ~/.config/ota/.jira-api-token
 
 # Automated label management tools
 ./monitor-jira-clear-labels
@@ -47,7 +47,7 @@ go vet ./...                        # Static analysis
 
 ### Jira Integration
 
-The tools integrate with Red Hat's Jira instance (https://issues.redhat.com) using bearer token authentication. The main workflow involves:
+The tools integrate with Red Hat's Jira instance (https://redhat.atlassian.net) using Basic authentication. The main workflow involves:
 
 1. **UpgradeBlocker** issues that need impact statement requests
 2. **ImpactStatementRequested** issues waiting for developer input  
@@ -63,7 +63,7 @@ The tools integrate with Red Hat's Jira instance (https://issues.redhat.com) usi
 
 ## Configuration
 
-Authentication requires a Jira bearer token stored at `~/.config/ota/jira-token` by default. The configuration directory path is determined by `internal/config/dir.go`.
+Authentication requires a Jira API token stored at `~/.config/ota/jira-api-token` by default. The configuration directory path is determined by `internal/config/dir.go`.
 
 ## Tools Purpose
 

--- a/go.mod
+++ b/go.mod
@@ -181,3 +181,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/ahmetb/gen-crd-api-reference-docs => github.com/ahmetb/gen-crd-api-reference-docs v0.3.0 // https://github.com/tektoncd/pipeline/issues/9997

--- a/internal/flagutil/jira.go
+++ b/internal/flagutil/jira.go
@@ -2,65 +2,52 @@ package flagutil
 
 import (
 	"flag"
-	"path/filepath"
 
-	"github.com/petr-muller/ota/internal/config"
 	"github.com/spf13/pflag"
 	prowflagutil "sigs.k8s.io/prow/pkg/flagutil"
 )
 
 const (
-	tokenFileName string = "jira-token"
+	defaultJiraEndpoint = "https://redhat.atlassian.net"
 )
 
 type JiraOptions struct {
 	prowflagutil.JiraOptions
-	apiTokenFileRef *string
-	endpointRef     *string
+	endpointRef *string
 }
 
 // AddFlags injects Jira options into the given FlagSet
 func (o *JiraOptions) AddFlags(fs *flag.FlagSet) {
 	o.JiraOptions.AddCustomizedFlags(fs,
-		prowflagutil.JiraDefaultEndpoint("https://redhat.atlassian.net"),
+		prowflagutil.JiraDefaultEndpoint(defaultJiraEndpoint),
 	)
 }
 
 // AddPFlags injects Jira options into the given pflag.FlagSet
 func (o *JiraOptions) AddPFlags(fs *pflag.FlagSet) {
-	configDir := config.MustOtaConfigDir()
-	defaultTokenPath := filepath.Join(configDir, tokenFileName)
-
 	// Use pflag to add the flags and bind them manually
-	var apiTokenFile, endpoint string
-	fs.StringVar(&apiTokenFile, "jira.api-token-file", defaultTokenPath, "Path to the file containing the Jira API token")
-	fs.StringVar(&endpoint, "jira.endpoint", "https://issues.redhat.com", "Jira endpoint URL")
+	var endpoint string
+	fs.StringVar(&endpoint, "jira.endpoint", defaultJiraEndpoint, "Jira endpoint URL")
 
 	// Set up a hook to copy values after parsing
 	fs.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		switch name {
-		case "jira.bearer-token-file":
-			// We'll handle this in a pre-run hook
 		case "jira.endpoint":
 			// We'll handle this in a pre-run hook
 		}
 		return pflag.NormalizedName(name)
 	})
 
-	// Store references for later use
-	o.apiTokenFileRef = &apiTokenFile
 	o.endpointRef = &endpoint
 }
 
 // SetFromPFlags copies values from pflag variables to the JiraOptions
 func (o *JiraOptions) SetFromPFlags() {
-	if o.apiTokenFileRef != nil {
-		goFlags := flag.NewFlagSet("temp", flag.ContinueOnError)
-		o.JiraOptions.AddCustomizedFlags(goFlags,
-			prowflagutil.JiraDefaultEndpoint(*o.endpointRef),
-		)
-		goFlags.Parse([]string{}) // Parse empty args to set defaults
-	}
+	goFlags := flag.NewFlagSet("temp", flag.ContinueOnError)
+	o.JiraOptions.AddCustomizedFlags(goFlags,
+		prowflagutil.JiraDefaultEndpoint(*o.endpointRef),
+	)
+	goFlags.Parse([]string{}) // Parse empty args to set defaults
 }
 
 func (o *JiraOptions) Validate() error {


### PR DESCRIPTION
Because Jira client uses Basic Auth since [1], the relevant
flags to run are `--jira-username` and `--jira-password-file`.
We do not need any flag for the bearer token.

[1]. https://github.com/petr-muller/ota/pull/75